### PR TITLE
Preprocessor defines to alter the keys used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,63 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots
+fastlane/test_output
+
+# Code Injection
+#
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/

--- a/NativeDisplayBrightness/AppDelegate.m
+++ b/NativeDisplayBrightness/AppDelegate.m
@@ -13,8 +13,14 @@
 #include <dlfcn.h>
 @import Carbon;
 
+
+
 #pragma mark - constants
 
+//#define BRIGHTNESS_DOWN_KEY kVK_F1
+//#define BRIGHTNESS_UP_KEY kVK_F2
+#define BRIGHTNESS_DOWN_KEY kVK_F16
+#define BRIGHTNESS_UP_KEY kVK_F17
 static NSString *brightnessValuePreferenceKey = @"brightness";
 static const float brightnessStep = 100/16.f;
 
@@ -45,7 +51,7 @@ CGEventRef keyboardCGEventCallback(CGEventTapProxy proxy,
     if (type == NX_KEYDOWN || type == NX_KEYUP || type == NX_FLAGSCHANGED)
     {
         int64_t keyCode = CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode);
-        if (keyCode == kVK_F2 || keyCode == kVK_F1)
+        if (keyCode == BRIGHTNESS_UP_KEY || keyCode == BRIGHTNESS_DOWN_KEY)
         {
             return NULL;
         }
@@ -102,7 +108,7 @@ CGEventRef keyboardCGEventCallback(CGEventTapProxy proxy,
 {
     [NSEvent addGlobalMonitorForEventsMatchingMask:NSEventMaskKeyDown | NSEventMaskKeyUp handler:^(NSEvent *_Nonnull event) {
         //NSLog(@"event!!");
-        if (event.keyCode == kVK_F1)
+        if (event.keyCode == BRIGHTNESS_DOWN_KEY)
         {
             if (event.type == NSEventTypeKeyDown)
             {
@@ -111,7 +117,7 @@ CGEventRef keyboardCGEventCallback(CGEventTapProxy proxy,
                 });
             }
         }
-        else if (event.keyCode == kVK_F2)
+        else if (event.keyCode == BRIGHTNESS_UP_KEY)
         {
             if (event.type == NSEventTypeKeyDown)
             {

--- a/NativeDisplayBrightness/AppDelegate.m
+++ b/NativeDisplayBrightness/AppDelegate.m
@@ -17,10 +17,8 @@
 
 #pragma mark - constants
 
-//#define BRIGHTNESS_DOWN_KEY kVK_F1
-//#define BRIGHTNESS_UP_KEY kVK_F2
-#define BRIGHTNESS_DOWN_KEY kVK_F16
-#define BRIGHTNESS_UP_KEY kVK_F17
+#define BRIGHTNESS_DOWN_KEY kVK_F1
+#define BRIGHTNESS_UP_KEY kVK_F2
 static NSString *brightnessValuePreferenceKey = @"brightness";
 static const float brightnessStep = 100/16.f;
 


### PR DESCRIPTION
I don't really know Objective-C, but I am pretty sure this isn't the best way to do this (as it's still hardcoded in the executable no less than before). However, now it's that much easier to change what keys you wish to use simply by altering the header.

As a bonus, Xcode seems to autocomplete `kVK_` to more keys.